### PR TITLE
Fixes feed entry link; closes #12

### DIFF
--- a/render.clj
+++ b/render.clj
@@ -181,7 +181,7 @@
                     link (str blog-root html)]]
           [::atom/entry
            [::atom/id link]
-           [::atom/link link]
+           [::atom/link {:href link}]
            [::atom/title title]
            [::atom/updated (rfc-3339 date)]
            [::atom/content {:type "html"}


### PR DESCRIPTION
Sets the entry URL as href attribute vs content to adhere to the atom feed spec.