### PR TITLE
Add blog description

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -6,6 +6,7 @@
  :tasks
  {:init (def opts (merge (cli/parse-opts *command-line-args*)
                          {:blog-title "REPL adventures"
+                          :blog-description "A blog mostly about Clojure and ClojureScript."
                           :out-dir "public"
                           :blog-root "https://blog.michielborkent.nl/"
                           :discuss-link "https://github.com/borkdude/blog/discussions/categories/posts"


### PR DESCRIPTION
Your blog's tagline got lost in a quickblog merge. This PR puts it back for you. :)